### PR TITLE
EventEmitter is not a constructor function type

### DIFF
--- a/types/components/plugins/LiveFile.d.ts
+++ b/types/components/plugins/LiveFile.d.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from 'fs';
-import * as EventEmitter from 'events';
+import { EventEmitter} from 'events';
 
 interface LiveFileOptions {
     path: string,


### PR DESCRIPTION
Need to do this to fix this error: 
> node_modules/hyper-express/types/components/plugins/LiveFile.d.ts(12,39): error TS2507: Type 'typeof EventEmitter' is not a constructor function type.