### PR TITLE
Improve type definitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 node_modules/

--- a/types/components/http/Request.d.ts
+++ b/types/components/http/Request.d.ts
@@ -164,9 +164,9 @@ export default class Request {
 
     /**
      * Returns query parameters from incoming request in Object form {key: value}
-     * @returns {Record<string, unknown>}
+     * @returns {Record<string, string>}
      */
-    get query_parameters(): Record<string, unknown>;
+    get query_parameters(): Record<string, string>;
 
     /**
      * Returns remote IP address in string format from incoming request.

--- a/types/components/http/Request.d.ts
+++ b/types/components/http/Request.d.ts
@@ -1,9 +1,9 @@
-import * as uWebsockets from 'uWebSockets.js';
 import { BusboyConfig } from 'busboy';
-import { Readable } from 'stream'
 import { ParamsDictionary } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
 import { Options, Ranges, Result } from 'range-parser';
+import { Readable } from 'stream';
+import * as uWebsockets from 'uWebSockets.js';
 import MultipartField from '../plugins/MultipartField';
 import Server from '../Server';
 
@@ -66,14 +66,14 @@ export default class Request {
      * @param {Any} default_value Default: {}
      * @returns {Promise} Promise
      */
-    json(default_value?: default_value): Promise<Object|default_value>;
+    json<T = any, D = any>(default_value?: D): Promise<T | D>;
 
     /**
      * Parses and resolves an Object of urlencoded values from body.
      *
      * @returns {Promise} Promise
      */
-    urlencoded(): Promise<Object>;
+    urlencoded<T = any>(): Promise<T>;
 
     /**
      * Parses incoming multipart form and allows for easy consumption of fields/values including files.
@@ -81,8 +81,8 @@ export default class Request {
      * @param {MultipartHandler} handler
      * @returns {Promise<void|String|Error>} A promise which is resolved once all multipart fields have been processed
      */
-    multipart(handler: MultipartHandler): Promise<MultipartLimitReject|Error>;
-    
+    multipart(handler: MultipartHandler): Promise<MultipartLimitReject | Error>;
+
     /**
      * Parses incoming multipart form and allows for easy consumption of fields/values including files.
      *
@@ -90,7 +90,7 @@ export default class Request {
      * @param {MultipartHandler} handler
      * @returns {Promise<void|MultipartLimitReject|Error>} A promise which is resolved once all multipart fields have been processed
      */
-    multipart(options: BusboyConfig, handler: MultipartHandler): Promise<MultipartLimitReject|Error>;
+    multipart(options: BusboyConfig, handler: MultipartHandler): Promise<MultipartLimitReject | Error>;
 
     /* HyperExpress Request Properties */
 
@@ -146,7 +146,7 @@ export default class Request {
 
     /**
      * Returns request headers from incoming request.
-     * @returns {Object}
+     * @returns {Record<string, unknown>}
      */
     get headers(): Record<string, unknown>;
 
@@ -160,13 +160,13 @@ export default class Request {
      * Returns path parameters from incoming request in Object form {key: value}
      * @returns {Record<string, unknown>}
      */
-    get path_parameters(): Object;
+    get path_parameters(): Record<string, unknown>;
 
     /**
      * Returns query parameters from incoming request in Object form {key: value}
      * @returns {Record<string, unknown>}
      */
-    get query_parameters(): Object;
+    get query_parameters(): Record<string, unknown>;
 
     /**
      * Returns remote IP address in string format from incoming request.

--- a/types/components/http/Request.d.ts
+++ b/types/components/http/Request.d.ts
@@ -146,9 +146,9 @@ export default class Request {
 
     /**
      * Returns request headers from incoming request.
-     * @returns {Record<string, unknown>}
+     * @returns {Record<string, string>}
      */
-    get headers(): Record<string, unknown>;
+    get headers(): Record<string, string>;
 
     /**
      * Returns cookies from incoming request.
@@ -158,9 +158,9 @@ export default class Request {
 
     /**
      * Returns path parameters from incoming request in Object form {key: value}
-     * @returns {Record<string, unknown>}
+     * @returns {Record<string, string>}
      */
-    get path_parameters(): Record<string, unknown>;
+    get path_parameters(): Record<string, string>;
 
     /**
      * Returns query parameters from incoming request in Object form {key: value}

--- a/types/components/http/Response.d.ts
+++ b/types/components/http/Response.d.ts
@@ -1,7 +1,7 @@
-import * as uWebsockets from 'uWebSockets.js';
 import * as Stream from 'stream';
-import { UserRouteHandler } from '../router/Router';
+import * as uWebsockets from 'uWebSockets.js';
 import LiveFile from '../plugins/LiveFile';
+import { UserRouteHandler } from '../router/Router';
 import Server from '../Server';
 
 type SendableData = string | Buffer | ArrayBuffer;
@@ -153,7 +153,7 @@ export default class Response {
      * @param {Object} body JSON body
      * @returns {Boolean} Boolean
      */
-    json(body: Object): boolean;
+    json(body: any): boolean;
 
     /**
      * This method is an alias of send() method except it accepts an object
@@ -164,7 +164,7 @@ export default class Response {
      * @param {String=} name
      * @returns {Boolean} Boolean
      */
-    jsonp(body: Object, name?: string): boolean;
+    jsonp(body: any, name?: string): boolean;
 
     /**
      * This method is an alias of send() method except it automatically sets
@@ -213,10 +213,10 @@ export default class Response {
 
     /* HyperExpress Response Properties */
 
-     /**
-     * Returns the underlying raw uWS.Response object.
-     * @returns {uWebsockets.Response}
-     */
+    /**
+    * Returns the underlying raw uWS.Response object.
+    * @returns {uWebsockets.Response}
+    */
     get raw(): uWebsockets.HttpResponse;
 
     /**


### PR DESCRIPTION
Add support to generics on `Request.json` and `Request.urlencoded`.
Fixed `path_parameters` and `query_parameters` to return `Record<string, unknown>` instead of `Object`.
Change `Object` to `any` on Response.json and Response.jsonp params.