### PR TITLE
make the exit handlers optional

### DIFF
--- a/src/components/Server.js
+++ b/src/components/Server.js
@@ -74,15 +74,18 @@ class Server extends Router {
      *
      * @param {Number} port
      * @param {String=} host Optional. Default: 0.0.0.0
+     * @param {Boolean=} handleExitEvents Optional. Default: true
      * @returns {Promise} Promise
      */
-    listen(port, host = '0.0.0.0') {
+    listen(port, host = '0.0.0.0', handleExitEvents = true) {
         const reference = this;
         return new Promise((resolve, reject) =>
             reference.#uws_instance.listen(host, port, (listen_socket) => {
                 if (listen_socket) {
                     reference.#listen_socket = listen_socket;
-                    reference._bind_exit_handler();
+                    if (handleExitEvents) {
+                        reference._bind_exit_handler();
+                    }
                     resolve(listen_socket);
                 } else {
                     reject('No Socket Received From uWebsockets.js');

--- a/types/components/Server.d.ts
+++ b/types/components/Server.d.ts
@@ -34,9 +34,10 @@ export default class Server extends Router {
      *
      * @param {Number} port
      * @param {String=} host Optional. Default: 0.0.0.0
+     * @param {Boolean=} handleExitEvents Optional. Default: true
      * @returns {Promise} Promise
      */
-    listen(port: number, host?: string): Promise<uWebsockets.us_listen_socket|string>;
+    listen(port: number, host?: string, handleExitEvents?: boolean): Promise<uWebsockets.us_listen_socket|string>;
 
     /**
      * Stops/Closes HyperExpress webserver instance.

--- a/types/components/Server.d.ts
+++ b/types/components/Server.d.ts
@@ -13,7 +13,8 @@ interface ServerConstructorOptions {
     fast_buffers?: boolean,
     fast_abort?: boolean,
     trust_proxy?: boolean,
-    max_body_length?: number
+    max_body_length?: number,
+    auto_close?: boolean
 }
 
 type GlobalErrorHandler = (request: Request, response: Response, error: Error) => void;
@@ -34,10 +35,9 @@ export default class Server extends Router {
      *
      * @param {Number} port
      * @param {String=} host Optional. Default: 0.0.0.0
-     * @param {Boolean=} handleExitEvents Optional. Default: true
      * @returns {Promise} Promise
      */
-    listen(port: number, host?: string, handleExitEvents?: boolean): Promise<uWebsockets.us_listen_socket|string>;
+    listen(port: number, host?: string): Promise<uWebsockets.us_listen_socket|string>;
 
     /**
      * Stops/Closes HyperExpress webserver instance.


### PR DESCRIPTION
This PR makes the process exit handlers registration optional, using the `auto_close` Server option param.
The default value is `true` (handlers are registered).