### PR TITLE
Fix trust_proxy read bug

### DIFF
--- a/src/components/http/Request.js
+++ b/src/components/http/Request.js
@@ -789,7 +789,7 @@ class Request extends stream.Readable {
     get ips() {
         let client_ip = this.ip;
         let proxy_ip = this.proxy_ip;
-        let trust_proxy = this.#master_context.trust_proxy;
+        let trust_proxy = this.#master_context.options.trust_proxy;
         let x_forwarded_for = this.get('X-Forwarded-For');
         if (trust_proxy && x_forwarded_for) return x_forwarded_for.split(',');
         return [client_ip, proxy_ip];
@@ -799,7 +799,7 @@ class Request extends stream.Readable {
      * ExpressJS: Parse the "Host" header field to a hostname.
      */
     get hostname() {
-        let trust_proxy = this.#master_context.trust_proxy;
+        let trust_proxy = this.#master_context.options.trust_proxy;
         let host = this.get('X-Forwarded-Host');
 
         if (!host || !trust_proxy) {


### PR DESCRIPTION
This fixes a bug reading the `trust_proxy` option. Currently the read of this option will always be undefined in the express compatibility members `ips()` and `hostname()`.