### PR TITLE
feat(types): added type for Websocket.on() method

### DIFF
--- a/types/components/ws/Websocket.d.ts
+++ b/types/components/ws/Websocket.d.ts
@@ -17,7 +17,7 @@ export class Websocket extends EventEmitter {
      * @param {Function} listener
      * @returns {Websocket}
      */
-    on(eventName: 'message' | 'close' | 'drain', listener: (...args: any[]) => void): this;
+    on(eventName: 'message' | 'close' | 'drain' | 'ping' | 'pong', listener: (...args: any[]) => void): this;
 
     /**
      * Alias of uWS.cork() method. Accepts a callback with multiple operations for network efficiency.

--- a/types/components/ws/Websocket.d.ts
+++ b/types/components/ws/Websocket.d.ts
@@ -14,6 +14,7 @@ export class Websocket extends EventEmitter {
      * Overrides EventEmitter.on() method with the specific implemented event names
      *
      * @param {String} eventName
+     * @param {String} listener
      * @returns {Websocket}
      */
     on(eventName: 'message' | 'close' | 'drain', listener: (...args: any[]) => void): this;

--- a/types/components/ws/Websocket.d.ts
+++ b/types/components/ws/Websocket.d.ts
@@ -11,6 +11,14 @@ export class Websocket extends EventEmitter {
     /* Websocket Methods */
 
     /**
+     * Overrides EventEmitter.on() method with the specific implemented event names
+     *
+     * @param {String} eventName
+     * @returns {Websocket}
+     */
+    on(eventName: 'message' | 'close' | 'drain', listener: (...args: any[]) => void): this;
+
+    /**
      * Alias of uWS.cork() method. Accepts a callback with multiple operations for network efficiency.
      *
      * @param {Function} callback

--- a/types/components/ws/Websocket.d.ts
+++ b/types/components/ws/Websocket.d.ts
@@ -14,7 +14,7 @@ export class Websocket extends EventEmitter {
      * Overrides EventEmitter.on() method with the specific implemented event names
      *
      * @param {String} eventName
-     * @param {String} listener
+     * @param {Function} listener
      * @returns {Websocket}
      */
     on(eventName: 'message' | 'close' | 'drain', listener: (...args: any[]) => void): this;


### PR DESCRIPTION
overrides the EventEmitter.on() method type - limiting the type of eventName to 'message' 'drain' and 'close' #122 