### PR TITLE
Fixing parameter types for the get() method

### DIFF
--- a/types/components/router/Router.d.ts
+++ b/types/components/router/Router.d.ts
@@ -80,7 +80,7 @@ export class Router {
      * @param {...(RouteOptions|MiddlewareHandler)} args
      */
     get(pattern: string, handler: UserRouteHandler): void;
-    get(pattern: string, ...handlers: [MiddlewareHandler, UserRouteHandler]): void;
+    get(pattern: string, ...handlers: [MiddlewareHandler[], UserRouteHandler]): void;
     get(pattern: string, options: UserRouteOptions, ...handlers: [MiddlewareHandler[], UserRouteHandler]): void;
 
     /**


### PR DESCRIPTION
The parameter types for "get" were slightly off compared to "post", "put", etc...