### PR TITLE
Prevent corking if the request has been aborted

### DIFF
--- a/src/components/http/Response.js
+++ b/src/components/http/Response.js
@@ -141,7 +141,9 @@ class Response {
             this.throw(new Error('HyperExpress: atomic(handler) -> handler must be a Javascript function'));
 
         // Cork the provided handler
-        this.#raw_response.cork(handler);
+        if(!this.completed)
+            this.#raw_response.cork(handler);
+
         return this;
     }
 


### PR DESCRIPTION
This change prevents the underlying `response.cork` method from being called if the request is already complete (i.e. it has been aborted by the client).