### PR TITLE
Don't wrap non-error instance uncaught errors

### DIFF
--- a/src/components/http/Response.js
+++ b/src/components/http/Response.js
@@ -782,9 +782,6 @@ class Response {
      * @returns {Response}
      */
     throw(error) {
-        // If the error is not an instance of Error, wrap it in an Error object that
-        if (!(error instanceof Error)) error = new Error(`ERR_CAUGHT_NON_ERROR_TYPE: ${error}`);
-
         // Trigger the global error handler
         this.route.app.handlers.on_error(this.#wrapped_request, this, error);
 

--- a/tests/components/http/scenarios/request_uncaught_rejections.js
+++ b/tests/components/http/scenarios/request_uncaught_rejections.js
@@ -26,11 +26,11 @@ router.post(scenario_endpoint, async (request, response) => {
             await new Promise((_, reject) => reject(new Error('MANUAL_DEEP_ERROR')));
         case 3:
             // Manually thrown non-Error object
-            throw 'MANUAL_SHALLOW_NON_ERROR';
+            throw 'NON_ERROR_MANUAL_SHALLOW_NON_ERROR';
         case 4:
             // Manually thrown non-Error object
             await (async () => {
-                throw 'MANUAL_DEEP_NON_ERROR';
+                throw 'NON_ERROR_MANUAL_DEEP_NON_ERROR';
             })();
         default:
             return response.json({
@@ -49,8 +49,8 @@ async function test_request_uncaught_rejections() {
     const promises = [
         [1, 'MANUAL_SHALLOW_ERROR'],
         [2, 'MANUAL_DEEP_ERROR'],
-        [3, 'ERR_CAUGHT_NON_ERROR_TYPE: MANUAL_SHALLOW_NON_ERROR'],
-        [4, 'ERR_CAUGHT_NON_ERROR_TYPE: MANUAL_DEEP_NON_ERROR'],
+        [3, 'NON_ERROR_MANUAL_SHALLOW_NON_ERROR'],
+        [4, 'NON_ERROR_MANUAL_DEEP_NON_ERROR'],
     ].map(
         ([scenario, expected_code]) =>
             new Promise(async (resolve) => {


### PR DESCRIPTION
The current implementation of automatically wrapping non-error instance uncaught errors can cause issues if your application is expecting said errors, such as in the case of having custom error classes defined.

I think it would make more sense for the developer to have more control over the thrown error and let them check the instance if they wish to do so. The current implementation is problematic as it will produce an error such as `ERR_CAUGHT_NON_ERROR_TYPE: [object Object]`.