### PR TITLE
fix: allow events to return a promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "mime-types": "^2.1.33",
                 "range-parser": "^1.2.1",
                 "type-is": "^1.6.18",
+                "typed-emitter": "^2.1.0",
                 "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.23.0"
             },
             "devDependencies": {
@@ -182,6 +183,15 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
         "node_modules/streamsearch": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -189,6 +199,12 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+            "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+            "optional": true
         },
         "node_modules/type-is": {
             "version": "1.6.18",
@@ -200,6 +216,14 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+            "optionalDependencies": {
+                "rxjs": "*"
             }
         },
         "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "mime-types": "^2.1.33",
         "range-parser": "^1.2.1",
         "type-is": "^1.6.18",
+        "typed-emitter": "^2.1.0",
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.23.0"
     },
     "devDependencies": {

--- a/types/components/ws/Websocket.d.ts
+++ b/types/components/ws/Websocket.d.ts
@@ -1,19 +1,22 @@
 import * as uWebsockets from 'uWebSockets.js';
 import { EventEmitter } from "events";
 import { Readable, Writable } from 'stream';
+import TypedEmitter from 'typed-emitter';
 import { SendableData } from "../http/Response";
 
 export type WebsocketContext = {
     [key: string]: string
 }
 
-export class Websocket<TUserData = unknown> extends EventEmitter {
-    /* EventEmitter Overrides */
-    on(eventName: 'message' | 'close' | 'drain' | 'ping' | 'pong', listener: (...args: any[]) => void): this;
-    once(eventName: 'message' | 'close' | 'drain' | 'ping' | 'pong', listener: (...args: any[]) => void): this;
+type Events = {
+    message: (...args: any[]) => void | Promise<void>;
+    close: (...args: any[]) => void | Promise<void>;
+    drain: (...args: any[]) => void | Promise<void>;
+    ping: (...args: any[]) => void | Promise<void>;
+    pong: (...args: any[]) => void | Promise<void>;
+}
 
-    /* Websocket Methods */
-
+export class Websocket<TUserData = unknown> extends (EventEmitter as new () => TypedEmitter<Events>) {
     /**
      * Alias of uWS.cork() method. Accepts a callback with multiple operations for network efficiency.
      *


### PR DESCRIPTION
This allows `.on()` to accept a promise as it's callback. For example this is very common.

```ts
ws.on('close', async () => {
  await db.doThing();
});
```

This also changes the class to using typed-emitter which makes it a lot easier to type the events. Would be nice if they were fully typed at some point too instead of using `args`.