### PR TITLE
Update package.json to bump uWebSockets.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "range-parser": "^1.2.1",
         "type-is": "^1.6.18",
         "typed-emitter": "^2.1.0",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.37.0"
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.38.0"
     },
     "devDependencies": {
         "@types/busboy": "^0.3.1",


### PR DESCRIPTION
uWebSockets Bump to v20.53.0 that:
Fixes the bug of upgrading to websocket within HttpResponse::cork callback.