### PR TITLE
Support listen on unix domain socket

### DIFF
--- a/docs/Server.md
+++ b/docs/Server.md
@@ -54,7 +54,7 @@ Below is a breakdown of the `Server` component which is an extended `Router` ins
     * **Note** port is required and host is `0.0.0.0` by default.
     * **Overload Types**:
       * `listen(String: path)`: Starts the uWebsockets server on specified unix domain socket.
-* `close(uws_socket?: socket)`: Closes the uWebsockets se@Brver gracefully.
+* `close(uws_socket?: socket)`: Closes the uWebsockets server gracefully.
     * **Note**: socket is not required.
 * `set_error_handler(Function: handler)`: Binds a global catch-all error handler that will attempt to catch mostsynchronous/asynchronous errors.
     * **Handler Parameters:** `(Request: request, Response: response, Error: error) => {}`.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -52,6 +52,8 @@ Below is a breakdown of the `Server` component which is an extended `Router` ins
 * `listen(Number: port, String?: host)`: Starts the uWebsockets server on specified port.
     * **Returns** a `Promise` and resolves `uw_listen_socket`.
     * **Note** port is required and host is `0.0.0.0` by default.
+    * **Overload Types**:
+      * `listen(String: path)`: Starts the uWebsockets server on specified unix domain socket.
 * `close(uws_socket?: socket)`: Closes the uWebsockets se@Brver gracefully.
     * **Note**: socket is not required.
 * `set_error_handler(Function: handler)`: Binds a global catch-all error handler that will attempt to catch mostsynchronous/asynchronous errors.

--- a/src/components/Server.js
+++ b/src/components/Server.js
@@ -117,7 +117,7 @@ class Server extends Router {
     /**
      * Starts HyperExpress webserver on specified port and host, or unix domain socket.
      *
-     * @param {Number|String} first Required. Port to listen on. Example: 80 or "/run/listener.sock"
+     * @param {Number|String} first Required. Port or unix domain socket path to listen on. Example: 80 or "/run/listener.sock"
      * @param {(String|function(import('uWebSockets.js').listen_socket):void)=} second Optional. Host or callback to be called when the server is listening. Default: "0.0.0.0"
      * @param {(function(import('uWebSockets.js').us_listen_socket):void)=} third Optional. Callback to be called when the server is listening.
      * @returns {Promise<import('uWebSockets.js').us_listen_socket>} Promise

--- a/types/components/Server.d.ts
+++ b/types/components/Server.d.ts
@@ -41,6 +41,14 @@ export class Server extends Router {
     listen(port: number, host?: string): Promise<uWebsockets.us_listen_socket|string>;
 
     /**
+     * Starts HyperExpress webserver on specified unix domain socket.
+     *
+     * @param {String} path
+     * @returns {Promise} Promise
+     */
+    listen(path: string): Promise<uWebsockets.us_listen_socket|string>;
+
+    /**
      * Stops/Closes HyperExpress webserver instance.
      *
      * @param {uWebSockets.us_listen_socket=} [listen_socket] Optional


### PR DESCRIPTION
This feature is supported by uWebSockets.js via [listen_unix()](https://unetworking.github.io/uWebSockets.js/generated/interfaces/TemplatedApp.html#listen_unix), so I figured I would submit this PR to add it to hyper-express, since I need to listen on unix domain sockets for my use case.

In my environment, hyper-express listening on a tcp port achieves 27,178 req/s, but listening on the unix domain socket achieves 47,088 req/s, which surpasses both hono and elysia bun frameworks when they're also listening on a unix domain socket. I tested using both oha and autocannon, and while the specific req/s numbers were different, the % change was still there.

Part of the large performance difference for my environment might be due to my sysctl tcp configuration, but regardless, socket file communication should always be faster than tcp port, as there is less overhead.

Are you able to run some benchmarks as well in your environment to see what performance difference you see?