### PR TITLE
fix: reflect .d.ts exports in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@
 const uWebsockets = require('uWebSockets.js');
 const Server = require('./src/components/Server.js');
 const Router = require('./src/components/router/Router.js');
+const Request = require('./src/components/http/Request.js');
+const Response = require('./src/components/http/Response.js');
+const LiveFile = require('./src/components/plugins/LiveFile.js');
+const MultipartField = require('./src/components/plugins/MultipartField.js');
+const SSEventStream = require('./src/components/plugins/SSEventStream.js');
+const Websocket = require('./src/components/ws/Websocket.js');
 
 // Disable the uWebsockets.js version header if not specified to be kept
 if (!process.env['KEEP_UWS_HEADER']) {
@@ -14,7 +20,13 @@ if (!process.env['KEEP_UWS_HEADER']) {
 
 // Expose Server and Router classes along with uWebSockets.js constants
 module.exports = {
+    compressors: uWebsockets,
     Server,
     Router,
-    compressors: uWebsockets,
+    Request,
+    Response,
+    LiveFile,
+    MultipartField,
+    SSEventStream,
+    Websocket,
 };


### PR DESCRIPTION
See: https://github.com/kartikk221/hyper-express/issues/249

Also note that in order to get full .d.ts parity one would need to convert the existing code-base into TypeScript .ts, however it would be quite a time-consuming mission just to have a single source of truth.