### PR TITLE
feat: express-like function call

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,4 +17,5 @@ module.exports = {
     Server,
     Router,
     compressors: uWebsockets,
+    express(...args) { return new Server(...args); },
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,3 +9,6 @@ export * from './components/plugins/LiveFile'
 export * from './components/plugins/MultipartField'
 export * from './components/plugins/SSEventStream'
 export * from './components/ws/Websocket'
+
+import { Server } from './components/Server';
+export const express: (...args: ConstructorParameters<typeof Server>) => Server;


### PR DESCRIPTION
Consider using (also) a different name (in both the .js and .d.ts function), perhaps "hyper", to avoid thikning it's just a "drop-in" replacement.