### PR TITLE
feat: send response on calling sendStatus

### DIFF
--- a/src/components/compatibility/ExpressResponse.js
+++ b/src/components/compatibility/ExpressResponse.js
@@ -84,7 +84,7 @@ class ExpressResponse {
     }
 
     sendStatus(status_code) {
-        return this.status(status_code);
+        return this.status(status_code).send();
     }
 
     set(field, value) {

--- a/tests/components/http/Response.js
+++ b/tests/components/http/Response.js
@@ -58,6 +58,7 @@ router.post(endpoint, async (request, response) => {
 
 // Bind router to webserver
 const { TEST_SERVER } = require('../Server.js');
+const { test_response_send_status } = require('./scenarios/response_send_status.js');
 TEST_SERVER.use(router);
 
 async function test_response_object() {
@@ -136,6 +137,9 @@ async function test_response_object() {
 
     // Verify the custom HTTP status code and message support
     await test_response_custom_status();
+
+    // Verify the custom HTTP status code and message support
+    await test_response_send_status();
 
     // Verify the behavior of the .header() and .cookie() methods
     await test_response_headers_behavior();

--- a/tests/components/http/scenarios/response_send_status.js
+++ b/tests/components/http/scenarios/response_send_status.js
@@ -1,0 +1,49 @@
+const { assert_log } = require('../../../scripts/operators.js');
+const { HyperExpress, fetch, server } = require('../../../configuration.js');
+const router = new HyperExpress.Router();
+const endpoint = '/tests/response';
+const scenario_endpoint = '/send-status';
+const endpoint_url = server.base + endpoint + scenario_endpoint;
+
+// Create Backend HTTP Route
+router.post(scenario_endpoint, async (request, response) => {
+    const { status } = await request.json();
+    response.sendStatus(status);
+});
+
+// Bind router to webserver
+const { TEST_SERVER } = require('../../Server.js');
+TEST_SERVER.use(endpoint, router);
+
+async function test_response_send_status() {
+    const group = 'RESPONSE';
+    const candidate = 'HyperExpress.Response.statusCode';
+
+    [
+        {
+            status: 200,
+        },
+        {
+            status: 609,
+        },
+    ].map(async ({ status }) => {
+        // Make a request to the server with a status code
+        const response = await fetch(endpoint_url, {
+            method: 'POST',
+            body: JSON.stringify({
+                status,
+            }),
+        });
+
+        // Validate the status code on the response
+        assert_log(
+            group,
+            `${candidate} Custom Status Code & Response Test - "HTTP ${status}"`,
+            () => response.status === status
+        );
+    });
+}
+
+module.exports = {
+    test_response_send_status,
+};


### PR DESCRIPTION
This PR modifies the Response.sendStatus to be more inline with Express by sending the request after setting the status 
Issue: https://github.com/kartikk221/hyper-express/issues/309

