### PR TITLE
perf: Setting the content-type in some of the methods has been changed to using the header method directly.

### DIFF
--- a/src/components/http/Response.js
+++ b/src/components/http/Response.js
@@ -745,7 +745,7 @@ class Response {
      * @returns {Boolean} Boolean
      */
     json(body) {
-        return this.type('json').send(JSON.stringify(body));
+        return this.header('content-type', 'application/json', true).send(JSON.stringify(body));
     }
 
     /**
@@ -760,7 +760,7 @@ class Response {
     jsonp(body, name) {
         let query_parameters = this._wrapped_request.query_parameters;
         let method_name = query_parameters['callback'] || name;
-        return this.type('js').send(`${method_name}(${JSON.stringify(body)})`);
+        return this.header('content-type', 'application/javascript', true).send(`${method_name}(${JSON.stringify(body)})`);
     }
 
     /**
@@ -771,7 +771,7 @@ class Response {
      * @returns {Boolean} Boolean
      */
     html(body) {
-        return this.type('html').send(body);
+        return this.header('content-type', 'text/html', true).send(body);
     }
 
     /**


### PR DESCRIPTION
In the `response.json`, `response.jsonp`, and `response.html` methods, the way the `Content-Type` is set should be changed to use the `header` method directly instead of invoking the `type` method. This change offers better performance.

This PR implements the change and compares the performance before and after the modification.

### Performance Test

Using `autocannon`, the following commands were run:
```
autocannon -c128 -p16 -d10 -w8 http://127.0.0.1:3000/json
autocannon -c128 -p16 -d10 -w8 http://127.0.0.1:3000/jsonp
autocannon -c128 -p16 -d10 -w8 http://127.0.0.1:3000/html
```

**Test Environment**:
- CPU: Intel i7-14700kF
- OS: Debian12 (Proxmox VE)

**Test Code**:
```javascript
import { Server } from 'hyper-express';

const text = 'data'.repeat(256);
const html = `<!DOCTYPE html><html><body><p>${text}</p></body></html>`;
const server = new Server();
server.get('/json', (req, res) => res.json({ data: text }));
server.get('/jsonp', (req, res) => res.jsonp({ data: text }, 'data'));
server.get('/html', (req, res) => res.html(html));
server.listen(3000, '127.0.0.1');
```

Each type of response was tested three times:

#### JSON:
**Before the modification**:
- 1847k, 1838k, 1824k
- 2.14 GB, 2.13 GB, 2.11 GB

**After the modification**:
- 2107k, 1986k, 2019k
- 2.41 GB, 2.27 GB, 2.31 GB

#### JSONP:
**Before the modification**:
- 1720k, 1678k, 1698k
- 2.01 GB, 1.96 GB, 1.99 GB

**After the modification**:
- 1905k, 1838k, 1958k
- 2.2 GB, 2.12 GB, 2.26 GB

#### HTML:
**Before the modification**:
- 2776k, 2817k, 2790k
- 3.3 GB, 3.35 GB, 3.32 GB

**After the modification**:
- 3529k, 3436k, 3535k
- 4.14 GB, 4.04 GB, 4.15 GB
