### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
             "version": "6.17.2",
             "license": "MIT",
             "dependencies": {
-                "accepts": "^1.3.7",
-                "busboy": "^1.0.0",
-                "cookie": "^0.4.1",
-                "cookie-signature": "^1.1.0",
-                "mime-types": "^2.1.33",
+                "accepts": "^1.3.8",
+                "busboy": "^1.6.0",
+                "cookie": "^1.0.1",
+                "cookie-signature": "^1.2.1",
+                "mime-types": "^2.1.35",
                 "range-parser": "^1.2.1",
                 "type-is": "^1.6.18",
                 "typed-emitter": "^2.1.0",
-                "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.48.0"
+                "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.49.0"
             },
             "devDependencies": {
-                "@types/busboy": "^0.3.1",
-                "@types/express": "^4.17.13",
-                "@types/node": "^16.11.6",
-                "typescript": "^5.0.4"
+                "@types/busboy": "^1.5.4",
+                "@types/express": "^5.0.0",
+                "@types/node": "^22.7.5",
+                "typescript": "^5.6.3"
             }
         },
         "node_modules/@types/body-parser": {
@@ -37,10 +37,11 @@
             }
         },
         "node_modules/@types/busboy": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.5.tgz",
-            "integrity": "sha512-ZFAS63bEBepOMEubHooylhwA4BcN2z/lhuJ/MkZXT4079za5kODWTmGZRDEUIoUbw2g/7NBe/ZxRSTK0yrPkgA==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+            "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -55,22 +56,24 @@
             }
         },
         "node_modules/@types/express": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
+            "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
+                "@types/express-serve-static-core": "^5.0.0",
                 "@types/qs": "*",
                 "@types/serve-static": "*"
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.41",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-            "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
+            "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -91,28 +94,35 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.61",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz",
-            "integrity": "sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q==",
-            "dev": true
+            "version": "22.7.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.10",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-            "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
-            "dev": true
+            "version": "6.9.16",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+            "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/mime": "^1",
                 "@types/node": "*"
@@ -153,11 +163,12 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.1.tgz",
+            "integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
             }
         },
         "node_modules/cookie-signature": {
@@ -255,10 +266,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -267,9 +279,16 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/uWebSockets.js": {
-            "version": "20.48.0",
-            "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#51ae1d1fd92dff77cbbdc7c431021f85578da1a6",
+            "version": "20.49.0",
+            "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#442087c0a01bf146acb7386910739ec81df06700",
             "license": "Apache-2.0"
         }
     }

--- a/package.json
+++ b/package.json
@@ -41,20 +41,20 @@
     },
     "homepage": "https://github.com/kartikk221/hyper-express#readme",
     "dependencies": {
-        "accepts": "^1.3.7",
-        "busboy": "^1.0.0",
-        "cookie": "^0.4.1",
-        "cookie-signature": "^1.1.0",
-        "mime-types": "^2.1.33",
+        "accepts": "^1.3.8",
+        "busboy": "^1.6.0",
+        "cookie": "^1.0.1",
+        "cookie-signature": "^1.2.1",
+        "mime-types": "^2.1.35",
         "range-parser": "^1.2.1",
         "type-is": "^1.6.18",
         "typed-emitter": "^2.1.0",
-        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.48.0"
+        "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.49.0"
     },
     "devDependencies": {
-        "@types/busboy": "^0.3.1",
-        "@types/express": "^4.17.13",
-        "@types/node": "^16.11.6",
-        "typescript": "^5.0.4"
+        "@types/busboy": "^1.5.4",
+        "@types/express": "^5.0.0",
+        "@types/node": "^22.7.5",
+        "typescript": "^5.6.3"
     }
 }


### PR DESCRIPTION
- Fixed `cookie` package vulnerabilities

> cookie  <0.7.0
> cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x

- Update `uWebSockets.js` package

> v20.49.0
> More threading functionality
> - Wrap App.adoptSocket(fd)
> - Add App.removeChildAppDescriptor
> - Bump uWS to v20.67.0

- Other packages updates