### PR TITLE
Allow setting 'url' to work with Vite development server

### DIFF
--- a/src/components/compatibility/ExpressRequest.js
+++ b/src/components/compatibility/ExpressRequest.js
@@ -1,6 +1,6 @@
 'use strict';
-const Negotiator = require('negotiator')
-const mime_types = require('mime-types')
+const Negotiator = require('negotiator');
+const mime_types = require('mime-types');
 const parse_range = require('range-parser');
 const type_is = require('type-is');
 const is_ip = require('net').isIP;
@@ -39,7 +39,7 @@ class ExpressRequest {
             return this.#negotiator.mediaTypes();
         }
 
-        const mimes = arrayTypes.map((type) => type.indexOf('/') === -1 ? mime_types.lookup(type) : type);
+        const mimes = arrayTypes.map((type) => (type.indexOf('/') === -1 ? mime_types.lookup(type) : type));
         const first = this.#negotiator.mediaType(mimes.filter((type) => typeof type === 'string'));
         return first ? arrayTypes[mimes.indexOf(first)] : false;
     }
@@ -111,6 +111,16 @@ class ExpressRequest {
 
     get originalUrl() {
         return this.url;
+    }
+
+    /**
+     * @benoitlahoz Only tested with `vite` middlewares used for SSR
+     * that actually change the `originalUrl` of the request.
+     *
+     * @see https://github.com/kartikk221/hyper-express/issues/324
+     */
+    set originalUrl(url) {
+        this.url = url;
     }
 
     get fresh() {

--- a/src/components/compatibility/ExpressResponse.js
+++ b/src/components/compatibility/ExpressResponse.js
@@ -14,6 +14,24 @@ class ExpressResponse {
         Object.keys(headers).forEach((name) => this.header(name, headers[name]));
     }
 
+    /**
+     * @benoitlahoz Only tested with `vite` middlewares used for SSR.
+     * `writeHead` method appears to have been removed from `express`
+     * but `vite` middlewares use it.
+     *
+     * Original `http` module method accepts 3 parameters, `headers` being the third
+     * but `vite` sends headers as second parameter and `undefined` as third.
+     *
+     * @see https://github.com/kartikk221/hyper-express/issues/324
+     * @see https://github.com/kartikk221/hyper-express/issues/22
+     */
+    writeHead(statusCode, headers) {
+        this.status(statusCode);
+        if (headers && typeof headers === 'object') {
+            Object.keys(headers).forEach((name) => this.header(name, headers[name]));
+        }
+    }
+
     setHeaders(headers) {
         this.writeHeaders(headers);
     }

--- a/src/components/compatibility/ExpressResponse.js
+++ b/src/components/compatibility/ExpressResponse.js
@@ -24,11 +24,20 @@ class ExpressResponse {
      *
      * @see https://github.com/kartikk221/hyper-express/issues/324
      * @see https://github.com/kartikk221/hyper-express/issues/22
+     *
+     * @see https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers
      */
-    writeHead(statusCode, headers) {
+    writeHead(statusCode, msgOrHeaders, headersOrUndefined) {
         this.status(statusCode);
-        if (headers && typeof headers === 'object') {
+
+        const setHeaders = (headers) => {
             Object.keys(headers).forEach((name) => this.header(name, headers[name]));
+        };
+
+        if (msgOrHeaders && typeof msgOrHeaders === 'object') {
+            setHeaders(msgOrHeaders);
+        } else if (headersOrUndefined && typeof headersOrUndefined === 'object') {
+            setHeaders(headersOrUndefined);
         }
     }
 

--- a/src/components/http/Request.js
+++ b/src/components/http/Request.js
@@ -828,6 +828,18 @@ class Request {
     }
 
     /**
+     * Allow to change request url.
+     *
+     * @benoitlahoz Only tested with `vite` middlewares used for SSR
+     * that actually change the `originalUrl` of the request.
+     *
+     * @see https://github.com/kartikk221/hyper-express/issues/324
+     */
+    set url(url) {
+        this._url = url;
+    }
+
+    /**
      * Returns path for incoming request.
      * @returns {String}
      */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,9 @@
 {
-  "compilerOptions": {
-    "target": "ES2021",
-    "moduleResolution": "node",
-    "typeRoots": [
-      "./types/*.d.ts",
-      "./node_modules/@types"
-    ],
-    "types": [
-      "node",
-      "express"
-    ]
-  },
-  "exclude": [
-    "./src"
-  ]
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "node",
+        "typeRoots": ["./types/*.d.ts", "./node_modules/@types"],
+        "types": ["node", "express"]
+    },
+    "exclude": ["./src"]
 }

--- a/types/components/http/Request.d.ts
+++ b/types/components/http/Request.d.ts
@@ -129,6 +129,16 @@ export class Request<Locals = DefaultRequestLocals> extends Readable {
     get url(): string;
 
     /**
+     * Allow to change request url.
+     *
+     * @benoitlahoz Only tested with `vite` middlewares used for SSR
+     * that actually change the `originalUrl` of the request.
+     *
+     * @see https://github.com/kartikk221/hyper-express/issues/324
+     */
+    set url(url: string);
+
+    /**
      * Returns path for incoming request.
      * @returns {String}
      */


### PR DESCRIPTION
This PR is related to #324, #249 and #22.

`Vite` middlewares used in development server for Server-Side Rendering are writing to ExpressRequest's `originalUrl` (HyperExpress Request's `url`). 

Additionally, they call the `writeHead` method of the ExpressResponse, which appears to have been removed from `Express`, but may be used by Vite on the `http` module response directly.

This PR adds setters for `originalUrl` and `url`, and implements the `writeHead` method on the ExpressResponse. 

A working example can be found [here](https://github.com/benoitlahoz/hyper-express-vite-vue).