### PR TITLE
add query setter

### DIFF
--- a/src/components/compatibility/ExpressRequest.js
+++ b/src/components/compatibility/ExpressRequest.js
@@ -1,6 +1,6 @@
 'use strict';
-const Negotiator = require('negotiator')
-const mime_types = require('mime-types')
+const Negotiator = require('negotiator');
+const mime_types = require('mime-types');
 const parse_range = require('range-parser');
 const type_is = require('type-is');
 const is_ip = require('net').isIP;
@@ -39,7 +39,7 @@ class ExpressRequest {
             return this.#negotiator.mediaTypes();
         }
 
-        const mimes = arrayTypes.map((type) => type.indexOf('/') === -1 ? mime_types.lookup(type) : type);
+        const mimes = arrayTypes.map((type) => (type.indexOf('/') === -1 ? mime_types.lookup(type) : type));
         const first = this.#negotiator.mediaType(mimes.filter((type) => typeof type === 'string'));
         return first ? arrayTypes[mimes.indexOf(first)] : false;
     }
@@ -174,6 +174,11 @@ class ExpressRequest {
     }
 
     get query() {
+        return this.query_parameters;
+    }
+
+    set query(value) {
+        this.query_parameters = value;
         return this.query_parameters;
     }
 

--- a/src/components/http/Request.js
+++ b/src/components/http/Request.js
@@ -879,6 +879,15 @@ class Request {
         this._query_parameters = querystring.parse(this._query);
         return this._query_parameters;
     }
+    /**
+     * Sets query parameters for incoming request.
+     * @param {Object.<string, string>} value
+     * @returns {Object.<string, string>}
+     */
+    set query_parameters(value) {
+        this._query_parameters = value;
+        return this._query_parameters;
+    }
 
     /**
      * Returns remote IP address in string format from incoming request.


### PR DESCRIPTION
#### Hello,

I’ve been working on a validation middleware to sanitize query parameters. My specific use case involved normalizing an email query parameter (e.g., trimming spaces and converting it to lowercase) so that the sanitized value could be used consistently in subsequent middleware or route handlers.

During implementation, I encountered the following errors when attempting to set a new value for the query property:

* TypeError: Cannot set property query of #<Request> which has only a getter.
* TypeError: Cannot set property query_parameters of #<Request> which has only a getter.

# Solution
I’ve identified the cause and resolved the issue. My approach ensures the query parameters are sanitized without conflicting with the Request object’s read-only properties. This solution should help anyone facing a similar problem.

### Looking forward to your feedback!

#### Thank you.